### PR TITLE
Better browser checking and source update fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ LIBRARYJS = --js-library src/library_recast.js
 all: clean test build
 
 update-source:
-	git submodule init; git submodule update; cd recastnavigation; git reset --hard origin/master; patch -p1 < ../src/recastnavigation.patch
+	git submodule init; git submodule update; cd recastnavigation; patch -p1 < ../src/recastnavigation.patch
 
 build: $(wildcard  lib/*.js)
 	mkdir -p $(BUILDDIR)


### PR DESCRIPTION
Tried using this library today, ran into a couple issues that this pull request should fix.

- the node environment check misses if it's a browser since now browsers have a `process` variable
- the `make update-source` command pulled the latest recastnavigation and tries to apply patches that are inappropriate for that revision

I'm still not able to get the library to work (`abort` errors when trying to build the navmesh) but these fixes might help others.